### PR TITLE
add -status to Write-Progress to fix pause after sync complete on PowerShell 2.0

### DIFF
--- a/docker/nsis/start.ps1
+++ b/docker/nsis/start.ps1
@@ -59,7 +59,7 @@ Do {
 
 }While (-Not $response.result.synchronized)
 
-Write-Progress -Activity "Waiting for monerod sync" -Completed
+Write-Progress -Activity "Waiting for monerod sync" -Completed -status "$percent% Complete:"
 
 Write-Output "Starting p2pool with wallet $Wallet"
 


### PR DESCRIPTION
Write-Progress expects status parameter in PowerShell 2.0. I don't see this behavior on Windows 10 (PowerShell 7.0)

![P2Pool-InstWin7](https://user-images.githubusercontent.com/7226914/135171803-c3584046-5c63-41ba-b971-746efc163d0f.png)